### PR TITLE
Fixing Issue 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+.classpath
+.project
+/.settings

--- a/src/test/java/org/openml/webapplication/fantail/characterizers/TestStatisticalCharacterizer.java
+++ b/src/test/java/org/openml/webapplication/fantail/characterizers/TestStatisticalCharacterizer.java
@@ -62,7 +62,7 @@ public class TestStatisticalCharacterizer {
 		double mean = 0.5;
 		double stdev = 0.5773502691896257; 
 		double skewness = 0.0;
-		double kurtosis = -6.0; // TODO: this is probably a bug!
+		double kurtosis = -6.0;
 		
 		Map<String, Double> results = new TreeMap<String, Double>();
 		results.put("MeanMeansOfNumericAtts", mean);

--- a/src/test/java/org/openml/webapplication/fantail/characterizers/TestStatisticalCharacterizer.java
+++ b/src/test/java/org/openml/webapplication/fantail/characterizers/TestStatisticalCharacterizer.java
@@ -22,7 +22,7 @@ public class TestStatisticalCharacterizer {
 		double mean = 0.5;
 		double stdev = 0.5773502691896257; 
 		double skewness = 0.0;
-		double kurtosis = -5.999999999999998; // TODO: this is probably a bug!
+		double kurtosis = -6.0;
 		
 		Map<String, Double> results = new TreeMap<String, Double>();
 		results.put("MeanMeansOfNumericAtts", mean);
@@ -62,7 +62,7 @@ public class TestStatisticalCharacterizer {
 		double mean = 0.5;
 		double stdev = 0.5773502691896257; 
 		double skewness = 0.0;
-		double kurtosis = -5.999999999999998; // TODO: this is probably a bug!
+		double kurtosis = -6.0; // TODO: this is probably a bug!
 		
 		Map<String, Double> results = new TreeMap<String, Double>();
 		results.put("MeanMeansOfNumericAtts", mean);

--- a/src/test/java/org/openml/webapplication/testutils/DatasetFactory.java
+++ b/src/test/java/org/openml/webapplication/testutils/DatasetFactory.java
@@ -10,6 +10,8 @@ import weka.core.Instances;
 
 public class DatasetFactory {
 	
+	private static final double DELTA = 1E-8;
+	
 	public static final Instances getXORNumericNoClass() {
 		ArrayList<Attribute> attributes = new ArrayList<Attribute>();
 		attributes.add(new Attribute("x1"));
@@ -127,7 +129,7 @@ public class DatasetFactory {
 				if (expected.get(feature) != null) {
 					differences.add(feature);
 				}
-			} else if (!result.get(feature).equals(expected.get(feature))) {
+			} else if (Math.abs(result.get(feature) - expected.get(feature)) > DELTA) {
 				differences.add(feature);
 			}
 		}


### PR DESCRIPTION
In Issue 12 a bug regarding the computation of the Kurtosis was reported.

However, the bug is only that Doubles are imprecise and need to be compared to each other in a relaxed way (i.e. with a delta, see Issue 12 for more information). Fixed the comparison of doubles in the DatasetFactory helper class.

Affects: JUnit Test for statistical meta features.

No Effect for the previous computation of meta features.