### PR TITLE
Dockerfile suitable for arm and amd releases

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.7-eclipse-temurin-11-alpine AS build
+FROM maven:3.9.9-amazoncorretto-11-alpine AS build
 COPY src /app/src
 COPY pom.xml /app
 RUN mvn -f /app/pom.xml clean package -DskipTests


### PR DESCRIPTION
The docker image `maven:3.9.7-eclipse-temurin-11-alpine` was only present for amd, not for arm, so the publish docker action failed.

Tested this new image locally.