### PR TITLE
Do not compute classDistribution if target variable is not nominal

### DIFF
--- a/data/test/datasets/cleveland.arff
+++ b/data/test/datasets/cleveland.arff
@@ -1,0 +1,568 @@
+%
+% Publication Request: 
+%    >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+%    This file describes the contents of the heart-disease directory.
+% 
+%    This directory contains 4 databases concerning heart disease diagnosis.
+%    All attributes are numeric-valued.  The data was collected from the
+%    four following locations:
+% 
+%      1. Cleveland Clinic Foundation (cleveland.data)
+%      2. Hungarian Institute of Cardiology, Budapest (hungarian.data)
+%      3. V.A. Medical Center, Long Beach, CA (long-beach-va.data)
+%      4. University Hospital, Zurich, Switzerland (switzerland.data)
+% 
+%    Each database has the same instance format.  While the databases have 76
+%    raw attributes, only 14 of them are actually used.  Thus I've taken the
+%    liberty of making 2 copies of each database: one with all the attributes
+%    and 1 with the 14 attributes actually used in past experiments.
+% 
+%    The authors of the databases have requested:
+% 
+%       ...that any publications resulting from the use of the data include the 
+%       names of the principal investigator responsible for the data collection
+%       at each institution.  They would be:
+% 
+%        1. Hungarian Institute of Cardiology. Budapest: Andras Janosi, M.D.
+%        2. University Hospital, Zurich, Switzerland: William Steinbrunn, M.D.
+%        3. University Hospital, Basel, Switzerland: Matthias Pfisterer, M.D.
+%        4. V.A. Medical Center, Long Beach and Cleveland Clinic Foundation:
+%           Robert Detrano, M.D., Ph.D.
+% 
+%    Thanks in advance for abiding by this request.
+% 
+%    David Aha
+%    July 22, 1988
+%    >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+% 
+% 1. Title: Heart Disease Databases
+% 
+% 2. Source Information:
+%    (a) Creators: 
+%        -- 1. Hungarian Institute of Cardiology. Budapest: Andras Janosi, M.D.
+%        -- 2. University Hospital, Zurich, Switzerland: William Steinbrunn, M.D.
+%        -- 3. University Hospital, Basel, Switzerland: Matthias Pfisterer, M.D.
+%        -- 4. V.A. Medical Center, Long Beach and Cleveland Clinic Foundation:
+%              Robert Detrano, M.D., Ph.D.
+%    (b) Donor: David W. Aha (aha@ics.uci.edu) (714) 856-8779   
+%    (c) Date: July, 1988
+% 
+% 3. Past Usage:
+%     1. Detrano,~R., Janosi,~A., Steinbrunn,~W., Pfisterer,~M., Schmid,~J.,
+%        Sandhu,~S., Guppy,~K., Lee,~S., \& Froelicher,~V. (1989).  {\it 
+%        International application of a new probability algorithm for the 
+%        diagnosis of coronary artery disease.}  {\it American Journal of 
+%        Cardiology}, {\it 64},304--310.
+%        -- International Probability Analysis 
+%        -- Address: Robert Detrano, M.D.
+%                    Cardiology 111-C
+%                    V.A. Medical Center
+%                    5901 E. 7th Street
+%                    Long Beach, CA 90028
+%        -- Results in percent accuracy: (for 0.5 probability threshold)
+%              Data Name:  CDF    CADENZA
+%           -- Hungarian   77     74
+%              Long beach  79     77
+%              Swiss       81     81
+%           -- Approximately a 77% correct classification accuracy with a
+%              logistic-regression-derived discriminant function
+%     2. David W. Aha & Dennis Kibler
+%        -- 
+%           
+%           
+%           -- Instance-based prediction of heart-disease presence with the 
+%              Cleveland database
+%              -- NTgrowth: 77.0% accuracy
+%              --       C4: 74.8% accuracy
+%     3. John Gennari
+%        -- Gennari, J.~H., Langley, P, \& Fisher, D. (1989). Models of
+%           incremental concept formation. {\it Artificial Intelligence, 40},
+%           11--61.
+%        -- Results: 
+%           -- The CLASSIT conceptual clustering system achieved a 78.9% accuracy
+%              on the Cleveland database.
+% 
+% 4. Relevant Information:
+%      This database contains 76 attributes, but all published experiments
+%      refer to using a subset of 14 of them.  In particular, the Cleveland
+%      database is the only one that has been used by ML researchers to 
+%      this date.  The "goal" field refers to the presence of heart disease
+%      in the patient.  It is integer valued from 0 (no presence) to 4.
+%      Experiments with the Cleveland database have concentrated on simply
+%      attempting to distinguish presence (values 1,2,3,4) from absence (value
+%      0).  
+%    
+%      The names and social security numbers of the patients were recently 
+%      removed from the database, replaced with dummy values.
+% 
+%      One file has been "processed", that one containing the Cleveland 
+%      database.  All four unprocessed files also exist in this directory.
+%     
+% 5. Number of Instances: 
+%         Database:    # of instances:
+%           Cleveland: 303
+%           Hungarian: 294
+%         Switzerland: 123
+%       Long Beach VA: 200
+% 
+% 6. Number of Attributes: 76 (including the predicted attribute)
+% 
+% 7. Attribute Information:
+%    -- Only 14 used
+%       -- 1. #3  (age)       
+%       -- 2. #4  (sex)       
+%       -- 3. #9  (cp)        
+%       -- 4. #10 (trestbps)  
+%       -- 5. #12 (chol)      
+%       -- 6. #16 (fbs)       
+%       -- 7. #19 (restecg)   
+%       -- 8. #32 (thalach)   
+%       -- 9. #38 (exang)     
+%       -- 10. #40 (oldpeak)   
+%       -- 11. #41 (slope)     
+%       -- 12. #44 (ca)        
+%       -- 13. #51 (thal)      
+%       -- 14. #58 (num)       (the predicted attribute)
+% 
+%    -- Complete attribute documentation:
+%       1 id: patient identification number
+%       2 ccf: social security number (I replaced this with a dummy value of 0)
+%       3 age: age in years
+%       4 sex: sex (1 = male; 0 = female)
+%       5 painloc: chest pain location (1 = substernal; 0 = otherwise)
+%       6 painexer (1 = provoked by exertion; 0 = otherwise)
+%       7 relrest (1 = relieved after rest; 0 = otherwise)
+%       8 pncaden (sum of 5, 6, and 7)
+%       9 cp: chest pain type
+%         -- Value 1: typical angina
+%         -- Value 2: atypical angina
+%         -- Value 3: non-anginal pain
+%         -- Value 4: asymptomatic
+%      10 trestbps: resting blood pressure (in mm Hg on admission to the 
+%         hospital)
+%      11 htn
+%      12 chol: serum cholestoral in mg/dl
+%      13 smoke: I believe this is 1 = yes; 0 = no (is or is not a smoker)
+%      14 cigs (cigarettes per day)
+%      15 years (number of years as a smoker)
+%      16 fbs: (fasting blood sugar > 120 mg/dl)  (1 = true; 0 = false)
+%      17 dm (1 = history of diabetes; 0 = no such history)
+%      18 famhist: family history of coronary artery disease (1 = yes; 0 = no)
+%      19 restecg: resting electrocardiographic results
+%         -- Value 0: normal
+%         -- Value 1: having ST-T wave abnormality (T wave inversions and/or ST 
+%                     elevation or depression of > 0.05 mV)
+%         -- Value 2: showing probable or definite left ventricular hypertrophy
+%                     by Estes' criteria
+%      20 ekgmo (month of exercise ECG reading)
+%      21 ekgday(day of exercise ECG reading)
+%      22 ekgyr (year of exercise ECG reading)
+%      23 dig (digitalis used furing exercise ECG: 1 = yes; 0 = no)
+%      24 prop (Beta blocker used during exercise ECG: 1 = yes; 0 = no)
+%      25 nitr (nitrates used during exercise ECG: 1 = yes; 0 = no)
+%      26 pro (calcium channel blocker used during exercise ECG: 1 = yes; 0 = no)
+%      27 diuretic (diuretic used used during exercise ECG: 1 = yes; 0 = no)
+%      28 proto: exercise protocol
+%           1 = Bruce     
+%           2 = Kottus
+%           3 = McHenry
+%           4 = fast Balke
+%           5 = Balke
+%           6 = Noughton 
+%           7 = bike 150 kpa min/min  (Not sure if "kpa min/min" is what was 
+%               written!)
+%           8 = bike 125 kpa min/min  
+%           9 = bike 100 kpa min/min
+%          10 = bike 75 kpa min/min
+%          11 = bike 50 kpa min/min
+%          12 = arm ergometer
+%      29 thaldur: duration of exercise test in minutes
+%      30 thaltime: time when ST measure depression was noted
+%      31 met: mets achieved
+%      32 thalach: maximum heart rate achieved
+%      33 thalrest: resting heart rate
+%      34 tpeakbps: peak exercise blood pressure (first of 2 parts)
+%      35 tpeakbpd: peak exercise blood pressure (second of 2 parts)
+%      36 dummy
+%      37 trestbpd: resting blood pressure
+%      38 exang: exercise induced angina (1 = yes; 0 = no)
+%      39 xhypo: (1 = yes; 0 = no)
+%      40 oldpeak = ST depression induced by exercise relative to rest
+%      41 slope: the slope of the peak exercise ST segment
+%         -- Value 1: upsloping
+%         -- Value 2: flat
+%         -- Value 3: downsloping
+%      42 rldv5: height at rest
+%      43 rldv5e: height at peak exercise
+%      44 ca: number of major vessels (0-3) colored by flourosopy
+%      45 restckm: irrelevant
+%      46 exerckm: irrelevant
+%      47 restef: rest raidonuclid (sp?) ejection fraction
+%      48 restwm: rest wall (sp?) motion abnormality
+%         0 = none
+%         1 = mild or moderate
+%         2 = moderate or severe
+%         3 = akinesis or dyskmem (sp?)
+%      49 exeref: exercise radinalid (sp?) ejection fraction
+%      50 exerwm: exercise wall (sp?) motion 
+%      51 thal: 3 = normal; 6 = fixed defect; 7 = reversable defect
+%      52 thalsev: not used
+%      53 thalpul: not used
+%      54 earlobe: not used
+%      55 cmo: month of cardiac cath (sp?)  (perhaps "call")
+%      56 cday: day of cardiac cath (sp?)
+%      57 cyr: year of cardiac cath (sp?)
+%      58 num: diagnosis of heart disease (angiographic disease status)
+%         -- Value 0: < 50% diameter narrowing
+%         -- Value 1: > 50% diameter narrowing
+%         (in any major vessel: attributes 59 through 68 are vessels)
+%      59 lmt
+%      60 ladprox
+%      61 laddist
+%      62 diag
+%      63 cxmain
+%      64 ramus
+%      65 om1
+%      66 om2
+%      67 rcaprox
+%      68 rcadist
+%      69 lvx1: not used
+%      70 lvx2: not used
+%      71 lvx3: not used
+%      72 lvx4: not used
+%      73 lvf: not used
+%      74 cathef: not used
+%      75 junk: not used
+%      76 name: last name of patient 
+%         (I replaced this with the dummy string "name")
+% 
+% 9. Missing Attribute Values: Several.  Distinguished with value -9.0.
+% 
+% 10. Class Distribution:
+%         Database:      0   1   2   3   4 Total
+%           Cleveland: 164  55  36  35  13   303
+%           Hungarian: 188  37  26  28  15   294
+%         Switzerland:   8  48  32  30   5   123
+%       Long Beach VA:  51  56  41  42  10   200
+% 
+
+@relation 'cleveland'
+@attribute 'age' real
+@attribute 'sex' { 0, 1}
+@attribute 'cp' { 1, 4, 3, 2}
+@attribute 'trestbps' real
+@attribute 'chol' real
+@attribute 'fbs' { 1, 0}
+@attribute 'restecg' { 2, 0, 1}
+@attribute 'thalach' real
+@attribute 'exang' { 0, 1}
+@attribute 'oldpeak' real
+% 'slope' is ordered
+@attribute 'slope' { 1,2,3}
+@attribute 'ca' real
+@attribute 'thal' { 6, 3, 7}
+@attribute 'num' real
+@data
+63,1,1,145,233,1,2,150,0,2.3,3,0,6,0
+67,1,4,160,286,0,2,108,1,1.5,2,3,3,2
+67,1,4,120,229,0,2,129,1,2.6,2,2,7,1
+37,1,3,130,250,0,0,187,0,3.5,3,0,3,0
+41,0,2,130,204,0,2,172,0,1.4,1,0,3,0
+56,1,2,120,236,0,0,178,0,0.8,1,0,3,0
+62,0,4,140,268,0,2,160,0,3.6,3,2,3,3
+57,0,4,120,354,0,0,163,1,0.6,1,0,3,0
+63,1,4,130,254,0,2,147,0,1.4,2,1,7,2
+53,1,4,140,203,1,2,155,1,3.1,3,0,7,1
+57,1,4,140,192,0,0,148,0,0.4,2,0,6,0
+56,0,2,140,294,0,2,153,0,1.3,2,0,3,0
+56,1,3,130,256,1,2,142,1,0.6,2,1,6,2
+44,1,2,120,263,0,0,173,0,0,1,0,7,0
+52,1,3,172,199,1,0,162,0,0.5,1,0,7,0
+57,1,3,150,168,0,0,174,0,1.6,1,0,3,0
+48,1,2,110,229,0,0,168,0,1,3,0,7,1
+54,1,4,140,239,0,0,160,0,1.2,1,0,3,0
+48,0,3,130,275,0,0,139,0,0.2,1,0,3,0
+49,1,2,130,266,0,0,171,0,0.6,1,0,3,0
+64,1,1,110,211,0,2,144,1,1.8,2,0,3,0
+58,0,1,150,283,1,2,162,0,1,1,0,3,0
+58,1,2,120,284,0,2,160,0,1.8,2,0,3,1
+58,1,3,132,224,0,2,173,0,3.2,1,2,7,3
+60,1,4,130,206,0,2,132,1,2.4,2,2,7,4
+50,0,3,120,219,0,0,158,0,1.6,2,0,3,0
+58,0,3,120,340,0,0,172,0,0,1,0,3,0
+66,0,1,150,226,0,0,114,0,2.6,3,0,3,0
+43,1,4,150,247,0,0,171,0,1.5,1,0,3,0
+40,1,4,110,167,0,2,114,1,2,2,0,7,3
+69,0,1,140,239,0,0,151,0,1.8,1,2,3,0
+60,1,4,117,230,1,0,160,1,1.4,1,2,7,2
+64,1,3,140,335,0,0,158,0,0,1,0,3,1
+59,1,4,135,234,0,0,161,0,0.5,2,0,7,0
+44,1,3,130,233,0,0,179,1,0.4,1,0,3,0
+42,1,4,140,226,0,0,178,0,0,1,0,3,0
+43,1,4,120,177,0,2,120,1,2.5,2,0,7,3
+57,1,4,150,276,0,2,112,1,0.6,2,1,6,1
+55,1,4,132,353,0,0,132,1,1.2,2,1,7,3
+61,1,3,150,243,1,0,137,1,1,2,0,3,0
+65,0,4,150,225,0,2,114,0,1,2,3,7,4
+40,1,1,140,199,0,0,178,1,1.4,1,0,7,0
+71,0,2,160,302,0,0,162,0,0.4,1,2,3,0
+59,1,3,150,212,1,0,157,0,1.6,1,0,3,0
+61,0,4,130,330,0,2,169,0,0,1,0,3,1
+58,1,3,112,230,0,2,165,0,2.5,2,1,7,4
+51,1,3,110,175,0,0,123,0,0.6,1,0,3,0
+50,1,4,150,243,0,2,128,0,2.6,2,0,7,4
+65,0,3,140,417,1,2,157,0,0.8,1,1,3,0
+53,1,3,130,197,1,2,152,0,1.2,3,0,3,0
+41,0,2,105,198,0,0,168,0,0,1,1,3,0
+65,1,4,120,177,0,0,140,0,0.4,1,0,7,0
+44,1,4,112,290,0,2,153,0,0,1,1,3,2
+44,1,2,130,219,0,2,188,0,0,1,0,3,0
+60,1,4,130,253,0,0,144,1,1.4,1,1,7,1
+54,1,4,124,266,0,2,109,1,2.2,2,1,7,1
+50,1,3,140,233,0,0,163,0,0.6,2,1,7,1
+41,1,4,110,172,0,2,158,0,0,1,0,7,1
+54,1,3,125,273,0,2,152,0,0.5,3,1,3,0
+51,1,1,125,213,0,2,125,1,1.4,1,1,3,0
+51,0,4,130,305,0,0,142,1,1.2,2,0,7,2
+46,0,3,142,177,0,2,160,1,1.4,3,0,3,0
+58,1,4,128,216,0,2,131,1,2.2,2,3,7,1
+54,0,3,135,304,1,0,170,0,0,1,0,3,0
+54,1,4,120,188,0,0,113,0,1.4,2,1,7,2
+60,1,4,145,282,0,2,142,1,2.8,2,2,7,2
+60,1,3,140,185,0,2,155,0,3,2,0,3,1
+54,1,3,150,232,0,2,165,0,1.6,1,0,7,0
+59,1,4,170,326,0,2,140,1,3.4,3,0,7,2
+46,1,3,150,231,0,0,147,0,3.6,2,0,3,1
+65,0,3,155,269,0,0,148,0,0.8,1,0,3,0
+67,1,4,125,254,1,0,163,0,0.2,2,2,7,3
+62,1,4,120,267,0,0,99,1,1.8,2,2,7,1
+65,1,4,110,248,0,2,158,0,0.6,1,2,6,1
+44,1,4,110,197,0,2,177,0,0,1,1,3,1
+65,0,3,160,360,0,2,151,0,0.8,1,0,3,0
+60,1,4,125,258,0,2,141,1,2.8,2,1,7,1
+51,0,3,140,308,0,2,142,0,1.5,1,1,3,0
+48,1,2,130,245,0,2,180,0,0.2,2,0,3,0
+58,1,4,150,270,0,2,111,1,0.8,1,0,7,3
+45,1,4,104,208,0,2,148,1,3,2,0,3,0
+53,0,4,130,264,0,2,143,0,0.4,2,0,3,0
+39,1,3,140,321,0,2,182,0,0,1,0,3,0
+68,1,3,180,274,1,2,150,1,1.6,2,0,7,3
+52,1,2,120,325,0,0,172,0,0.2,1,0,3,0
+44,1,3,140,235,0,2,180,0,0,1,0,3,0
+47,1,3,138,257,0,2,156,0,0,1,0,3,0
+53,0,3,128,216,0,2,115,0,0,1,0,?,0
+53,0,4,138,234,0,2,160,0,0,1,0,3,0
+51,0,3,130,256,0,2,149,0,0.5,1,0,3,0
+66,1,4,120,302,0,2,151,0,0.4,2,0,3,0
+62,0,4,160,164,0,2,145,0,6.2,3,3,7,3
+62,1,3,130,231,0,0,146,0,1.8,2,3,7,0
+44,0,3,108,141,0,0,175,0,0.6,2,0,3,0
+63,0,3,135,252,0,2,172,0,0,1,0,3,0
+52,1,4,128,255,0,0,161,1,0,1,1,7,1
+59,1,4,110,239,0,2,142,1,1.2,2,1,7,2
+60,0,4,150,258,0,2,157,0,2.6,2,2,7,3
+52,1,2,134,201,0,0,158,0,0.8,1,1,3,0
+48,1,4,122,222,0,2,186,0,0,1,0,3,0
+45,1,4,115,260,0,2,185,0,0,1,0,3,0
+34,1,1,118,182,0,2,174,0,0,1,0,3,0
+57,0,4,128,303,0,2,159,0,0,1,1,3,0
+71,0,3,110,265,1,2,130,0,0,1,1,3,0
+49,1,3,120,188,0,0,139,0,2,2,3,7,3
+54,1,2,108,309,0,0,156,0,0,1,0,7,0
+59,1,4,140,177,0,0,162,1,0,1,1,7,2
+57,1,3,128,229,0,2,150,0,0.4,2,1,7,1
+61,1,4,120,260,0,0,140,1,3.6,2,1,7,2
+39,1,4,118,219,0,0,140,0,1.2,2,0,7,3
+61,0,4,145,307,0,2,146,1,1,2,0,7,1
+56,1,4,125,249,1,2,144,1,1.2,2,1,3,1
+52,1,1,118,186,0,2,190,0,0,2,0,6,0
+43,0,4,132,341,1,2,136,1,3,2,0,7,2
+62,0,3,130,263,0,0,97,0,1.2,2,1,7,2
+41,1,2,135,203,0,0,132,0,0,2,0,6,0
+58,1,3,140,211,1,2,165,0,0,1,0,3,0
+35,0,4,138,183,0,0,182,0,1.4,1,0,3,0
+63,1,4,130,330,1,2,132,1,1.8,1,3,7,3
+65,1,4,135,254,0,2,127,0,2.8,2,1,7,2
+48,1,4,130,256,1,2,150,1,0,1,2,7,3
+63,0,4,150,407,0,2,154,0,4,2,3,7,4
+51,1,3,100,222,0,0,143,1,1.2,2,0,3,0
+55,1,4,140,217,0,0,111,1,5.6,3,0,7,3
+65,1,1,138,282,1,2,174,0,1.4,2,1,3,1
+45,0,2,130,234,0,2,175,0,0.6,2,0,3,0
+56,0,4,200,288,1,2,133,1,4,3,2,7,3
+54,1,4,110,239,0,0,126,1,2.8,2,1,7,3
+44,1,2,120,220,0,0,170,0,0,1,0,3,0
+62,0,4,124,209,0,0,163,0,0,1,0,3,0
+54,1,3,120,258,0,2,147,0,0.4,2,0,7,0
+51,1,3,94,227,0,0,154,1,0,1,1,7,0
+29,1,2,130,204,0,2,202,0,0,1,0,3,0
+51,1,4,140,261,0,2,186,1,0,1,0,3,0
+43,0,3,122,213,0,0,165,0,0.2,2,0,3,0
+55,0,2,135,250,0,2,161,0,1.4,2,0,3,0
+70,1,4,145,174,0,0,125,1,2.6,3,0,7,4
+62,1,2,120,281,0,2,103,0,1.4,2,1,7,3
+35,1,4,120,198,0,0,130,1,1.6,2,0,7,1
+51,1,3,125,245,1,2,166,0,2.4,2,0,3,0
+59,1,2,140,221,0,0,164,1,0,1,0,3,0
+59,1,1,170,288,0,2,159,0,0.2,2,0,7,1
+52,1,2,128,205,1,0,184,0,0,1,0,3,0
+64,1,3,125,309,0,0,131,1,1.8,2,0,7,1
+58,1,3,105,240,0,2,154,1,0.6,2,0,7,0
+47,1,3,108,243,0,0,152,0,0,1,0,3,1
+57,1,4,165,289,1,2,124,0,1,2,3,7,4
+41,1,3,112,250,0,0,179,0,0,1,0,3,0
+45,1,2,128,308,0,2,170,0,0,1,0,3,0
+60,0,3,102,318,0,0,160,0,0,1,1,3,0
+52,1,1,152,298,1,0,178,0,1.2,2,0,7,0
+42,0,4,102,265,0,2,122,0,0.6,2,0,3,0
+67,0,3,115,564,0,2,160,0,1.6,2,0,7,0
+55,1,4,160,289,0,2,145,1,0.8,2,1,7,4
+64,1,4,120,246,0,2,96,1,2.2,3,1,3,3
+70,1,4,130,322,0,2,109,0,2.4,2,3,3,1
+51,1,4,140,299,0,0,173,1,1.6,1,0,7,1
+58,1,4,125,300,0,2,171,0,0,1,2,7,1
+60,1,4,140,293,0,2,170,0,1.2,2,2,7,2
+68,1,3,118,277,0,0,151,0,1,1,1,7,0
+46,1,2,101,197,1,0,156,0,0,1,0,7,0
+77,1,4,125,304,0,2,162,1,0,1,3,3,4
+54,0,3,110,214,0,0,158,0,1.6,2,0,3,0
+58,0,4,100,248,0,2,122,0,1,2,0,3,0
+48,1,3,124,255,1,0,175,0,0,1,2,3,0
+57,1,4,132,207,0,0,168,1,0,1,0,7,0
+52,1,3,138,223,0,0,169,0,0,1,?,3,0
+54,0,2,132,288,1,2,159,1,0,1,1,3,0
+35,1,4,126,282,0,2,156,1,0,1,0,7,1
+45,0,2,112,160,0,0,138,0,0,2,0,3,0
+70,1,3,160,269,0,0,112,1,2.9,2,1,7,3
+53,1,4,142,226,0,2,111,1,0,1,0,7,0
+59,0,4,174,249,0,0,143,1,0,2,0,3,1
+62,0,4,140,394,0,2,157,0,1.2,2,0,3,0
+64,1,4,145,212,0,2,132,0,2,2,2,6,4
+57,1,4,152,274,0,0,88,1,1.2,2,1,7,1
+52,1,4,108,233,1,0,147,0,0.1,1,3,7,0
+56,1,4,132,184,0,2,105,1,2.1,2,1,6,1
+43,1,3,130,315,0,0,162,0,1.9,1,1,3,0
+53,1,3,130,246,1,2,173,0,0,1,3,3,0
+48,1,4,124,274,0,2,166,0,0.5,2,0,7,3
+56,0,4,134,409,0,2,150,1,1.9,2,2,7,2
+42,1,1,148,244,0,2,178,0,0.8,1,2,3,0
+59,1,1,178,270,0,2,145,0,4.2,3,0,7,0
+60,0,4,158,305,0,2,161,0,0,1,0,3,1
+63,0,2,140,195,0,0,179,0,0,1,2,3,0
+42,1,3,120,240,1,0,194,0,0.8,3,0,7,0
+66,1,2,160,246,0,0,120,1,0,2,3,6,2
+54,1,2,192,283,0,2,195,0,0,1,1,7,1
+69,1,3,140,254,0,2,146,0,2,2,3,7,2
+50,1,3,129,196,0,0,163,0,0,1,0,3,0
+51,1,4,140,298,0,0,122,1,4.2,2,3,7,3
+43,1,4,132,247,1,2,143,1,0.1,2,?,7,1
+62,0,4,138,294,1,0,106,0,1.9,2,3,3,2
+68,0,3,120,211,0,2,115,0,1.5,2,0,3,0
+67,1,4,100,299,0,2,125,1,0.9,2,2,3,3
+69,1,1,160,234,1,2,131,0,0.1,2,1,3,0
+45,0,4,138,236,0,2,152,1,0.2,2,0,3,0
+50,0,2,120,244,0,0,162,0,1.1,1,0,3,0
+59,1,1,160,273,0,2,125,0,0,1,0,3,1
+50,0,4,110,254,0,2,159,0,0,1,0,3,0
+64,0,4,180,325,0,0,154,1,0,1,0,3,0
+57,1,3,150,126,1,0,173,0,0.2,1,1,7,0
+64,0,3,140,313,0,0,133,0,0.2,1,0,7,0
+43,1,4,110,211,0,0,161,0,0,1,0,7,0
+45,1,4,142,309,0,2,147,1,0,2,3,7,3
+58,1,4,128,259,0,2,130,1,3,2,2,7,3
+50,1,4,144,200,0,2,126,1,0.9,2,0,7,3
+55,1,2,130,262,0,0,155,0,0,1,0,3,0
+62,0,4,150,244,0,0,154,1,1.4,2,0,3,1
+37,0,3,120,215,0,0,170,0,0,1,0,3,0
+38,1,1,120,231,0,0,182,1,3.8,2,0,7,4
+41,1,3,130,214,0,2,168,0,2,2,0,3,0
+66,0,4,178,228,1,0,165,1,1,2,2,7,3
+52,1,4,112,230,0,0,160,0,0,1,1,3,1
+56,1,1,120,193,0,2,162,0,1.9,2,0,7,0
+46,0,2,105,204,0,0,172,0,0,1,0,3,0
+46,0,4,138,243,0,2,152,1,0,2,0,3,0
+64,0,4,130,303,0,0,122,0,2,2,2,3,0
+59,1,4,138,271,0,2,182,0,0,1,0,3,0
+41,0,3,112,268,0,2,172,1,0,1,0,3,0
+54,0,3,108,267,0,2,167,0,0,1,0,3,0
+39,0,3,94,199,0,0,179,0,0,1,0,3,0
+53,1,4,123,282,0,0,95,1,2,2,2,7,3
+63,0,4,108,269,0,0,169,1,1.8,2,2,3,1
+34,0,2,118,210,0,0,192,0,0.7,1,0,3,0
+47,1,4,112,204,0,0,143,0,0.1,1,0,3,0
+67,0,3,152,277,0,0,172,0,0,1,1,3,0
+54,1,4,110,206,0,2,108,1,0,2,1,3,3
+66,1,4,112,212,0,2,132,1,0.1,1,1,3,2
+52,0,3,136,196,0,2,169,0,0.1,2,0,3,0
+55,0,4,180,327,0,1,117,1,3.4,2,0,3,2
+49,1,3,118,149,0,2,126,0,0.8,1,3,3,1
+74,0,2,120,269,0,2,121,1,0.2,1,1,3,0
+54,0,3,160,201,0,0,163,0,0,1,1,3,0
+54,1,4,122,286,0,2,116,1,3.2,2,2,3,3
+56,1,4,130,283,1,2,103,1,1.6,3,0,7,2
+46,1,4,120,249,0,2,144,0,0.8,1,0,7,1
+49,0,2,134,271,0,0,162,0,0,2,0,3,0
+42,1,2,120,295,0,0,162,0,0,1,0,3,0
+41,1,2,110,235,0,0,153,0,0,1,0,3,0
+41,0,2,126,306,0,0,163,0,0,1,0,3,0
+49,0,4,130,269,0,0,163,0,0,1,0,3,0
+61,1,1,134,234,0,0,145,0,2.6,2,2,3,2
+60,0,3,120,178,1,0,96,0,0,1,0,3,0
+67,1,4,120,237,0,0,71,0,1,2,0,3,2
+58,1,4,100,234,0,0,156,0,0.1,1,1,7,2
+47,1,4,110,275,0,2,118,1,1,2,1,3,1
+52,1,4,125,212,0,0,168,0,1,1,2,7,3
+62,1,2,128,208,1,2,140,0,0,1,0,3,0
+57,1,4,110,201,0,0,126,1,1.5,2,0,6,0
+58,1,4,146,218,0,0,105,0,2,2,1,7,1
+64,1,4,128,263,0,0,105,1,0.2,2,1,7,0
+51,0,3,120,295,0,2,157,0,0.6,1,0,3,0
+43,1,4,115,303,0,0,181,0,1.2,2,0,3,0
+42,0,3,120,209,0,0,173,0,0,2,0,3,0
+67,0,4,106,223,0,0,142,0,0.3,1,2,3,0
+76,0,3,140,197,0,1,116,0,1.1,2,0,3,0
+70,1,2,156,245,0,2,143,0,0,1,0,3,0
+57,1,2,124,261,0,0,141,0,0.3,1,0,7,1
+44,0,3,118,242,0,0,149,0,0.3,2,1,3,0
+58,0,2,136,319,1,2,152,0,0,1,2,3,3
+60,0,1,150,240,0,0,171,0,0.9,1,0,3,0
+44,1,3,120,226,0,0,169,0,0,1,0,3,0
+61,1,4,138,166,0,2,125,1,3.6,2,1,3,4
+42,1,4,136,315,0,0,125,1,1.8,2,0,6,2
+52,1,4,128,204,1,0,156,1,1,2,0,?,2
+59,1,3,126,218,1,0,134,0,2.2,2,1,6,2
+40,1,4,152,223,0,0,181,0,0,1,0,7,1
+42,1,3,130,180,0,0,150,0,0,1,0,3,0
+61,1,4,140,207,0,2,138,1,1.9,1,1,7,1
+66,1,4,160,228,0,2,138,0,2.3,1,0,6,0
+46,1,4,140,311,0,0,120,1,1.8,2,2,7,2
+71,0,4,112,149,0,0,125,0,1.6,2,0,3,0
+59,1,1,134,204,0,0,162,0,0.8,1,2,3,1
+64,1,1,170,227,0,2,155,0,0.6,2,0,7,0
+66,0,3,146,278,0,2,152,0,0,2,1,3,0
+39,0,3,138,220,0,0,152,0,0,2,0,3,0
+57,1,2,154,232,0,2,164,0,0,1,1,3,1
+58,0,4,130,197,0,0,131,0,0.6,2,0,3,0
+57,1,4,110,335,0,0,143,1,3,2,1,7,2
+47,1,3,130,253,0,0,179,0,0,1,0,3,0
+55,0,4,128,205,0,1,130,1,2,2,1,7,3
+35,1,2,122,192,0,0,174,0,0,1,0,3,0
+61,1,4,148,203,0,0,161,0,0,1,1,7,2
+58,1,4,114,318,0,1,140,0,4.4,3,3,6,4
+58,0,4,170,225,1,2,146,1,2.8,2,2,6,2
+58,1,2,125,220,0,0,144,0,0.4,2,?,7,0
+56,1,2,130,221,0,2,163,0,0,1,0,7,0
+56,1,2,120,240,0,0,169,0,0,3,0,3,0
+67,1,3,152,212,0,2,150,0,0.8,2,0,7,1
+55,0,2,132,342,0,0,166,0,1.2,1,0,3,0
+44,1,4,120,169,0,0,144,1,2.8,3,0,6,2
+63,1,4,140,187,0,2,144,1,4,1,2,7,2
+63,0,4,124,197,0,0,136,1,0,2,0,3,1
+41,1,2,120,157,0,0,182,0,0,1,0,3,0
+59,1,4,164,176,1,2,90,0,1,2,2,6,3
+57,0,4,140,241,0,0,123,1,0.2,2,0,7,1
+45,1,1,110,264,0,0,132,0,1.2,2,0,7,1
+68,1,4,144,193,1,0,141,0,3.4,2,2,7,2
+57,1,4,130,131,0,0,115,1,1.2,2,1,7,3
+57,0,2,130,236,0,2,174,0,0,2,1,3,1
+38,1,3,138,175,0,0,173,0,0,1,?,3,0

--- a/src/main/java/org/openml/webapplication/features/AttributeSummarizer.java
+++ b/src/main/java/org/openml/webapplication/features/AttributeSummarizer.java
@@ -57,15 +57,15 @@ public class AttributeSummarizer {
 	 *
 	 * @param attribute The Weka Attribute of which data should be summarized
 	 * @param isTarget Is this attribute a target variable
-	 * @param singleTarget Is there only one target variable
+	 * @param singleNominalTarget Is there only one target variable, which is nominal?
 	 * @param numTargetClasses Null if there is not a single target, otherwise the attribute.numClasses() of the target
 	 *                         attribute
 	 */
-	public AttributeSummarizer(Attribute attribute, boolean isTarget, boolean singleTarget, Integer numTargetClasses) {
+	public AttributeSummarizer(Attribute attribute, boolean isTarget, boolean singleNominalTarget, Integer numTargetClasses) {
 		this.attribute = attribute;
 		this.isTarget = isTarget;
 		this.missingCount = 0;
-		this.trackClassDistribution = attribute.isNominal() && singleTarget;
+		this.trackClassDistribution = singleNominalTarget && attribute.isNominal();
 		if (trackClassDistribution) {
 			classDistribution = new int[attribute.numValues()][numTargetClasses];
 		} else {

--- a/src/main/java/org/openml/webapplication/features/FeatureExtractor.java
+++ b/src/main/java/org/openml/webapplication/features/FeatureExtractor.java
@@ -50,17 +50,18 @@ public class FeatureExtractor {
 	public static List<Feature> getFeatures(ArffLoader.ArffReader arffReader, String targetVariables) throws IOException {
 		final Instances structure = arffReader.getStructure();
 		final Set<String> targetAttributeNames = getTargetClasses(structure, targetVariables);
-		final boolean singleTargetClass = targetAttributeNames.size() == 1;
-		if (singleTargetClass) {
+		final boolean singleTarget = targetAttributeNames.size() == 1;
+		if (singleTarget) {
 			structure.setClass(structure.attribute(targetVariables));
 		}
-		final Integer numClasses = singleTargetClass ? structure.numClasses() : null;
+		final boolean singleNominalTarget = singleTarget && structure.classAttribute().isNominal();
+		final Integer numClasses = singleTarget ? structure.numClasses() : null;
 
 		final List<AttributeSummarizer> statistics = IntStream.range(0, structure.numAttributes())
 				.mapToObj(structure::attribute)
 				.map(attribute -> {
 					boolean isTarget = targetAttributeNames.contains(attribute.name());
-					return new AttributeSummarizer(attribute, isTarget, singleTargetClass, numClasses);
+					return new AttributeSummarizer(attribute, isTarget, singleNominalTarget, numClasses);
 				})
 				.collect(Collectors.toList());
 

--- a/src/test/java/org/openml/webapplication/features/TestExtractFeatures.java
+++ b/src/test/java/org/openml/webapplication/features/TestExtractFeatures.java
@@ -61,4 +61,18 @@ public class TestExtractFeatures {
         assertEquals(81.64285714285714, feature.getMeanValue(), DELTA);
         assertEquals(10.285218242007035, feature.getStandardDeviation(), DELTA);
     }
+
+    /**
+     * The target is real, so no ClassDistribution should be summarized for any attribute.
+     */
+    @Test
+    public final void testFeatureExtractionWithRealTarget() throws Exception {
+        String targetAttribute = "num";
+        Reader reader = new FileReader("data/test/datasets/cleveland.arff");
+        ArffLoader.ArffReader dataset = new ArffLoader.ArffReader(reader, 1000, false);
+        List<DataFeature.Feature> features = FeatureExtractor.getFeatures(dataset, targetAttribute);
+        for (DataFeature.Feature feature : features) {
+            assertEquals("[]", feature.getClassDistribution());
+        }
+    }
 }


### PR DESCRIPTION
(PR https://github.com/openml/EvaluationEngine/pull/43 should fix the unittests.)

We've got errors of the Evaluation Engine. Probably for a while already, but we're missing good monitoring. These errors surfaced when getting the Evaluation Engine to work on the new test server (openml5).

This seems to be an error introduced by me in https://github.com/openml/EvaluationEngine/pull/39/. That PR was a bit too bulky, and the code was (is) not tested properly.

Hereby a fix: it only makes sense to compute the class distrubtion of a variable if the class is nominal.