### PR TITLE
Release/v1.2.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,9 @@
-FROM maven:3.9.9-amazoncorretto-11-alpine AS build
+FROM maven:3.9.11-amazoncorretto-11-alpine AS build
 COPY src /app/src
 COPY pom.xml /app
 RUN mvn -f /app/pom.xml clean package -DskipTests
 
-FROM openjdk:11-slim-bullseye
-RUN useradd --create-home unprivileged-user
-USER unprivileged-user
+FROM amazoncorretto:11-alpine3.22
 
 COPY --from=build /app/target/EvaluationEngine-*-jar-with-dependencies.jar /usr/local/lib/evaluation-engine.jar
 ENTRYPOINT ["java", "-jar", "/usr/local/lib/evaluation-engine.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openml</groupId>
   <artifactId>EvaluationEngine</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <name>EvaluationEngine</name>
   <description>OpenML EvaluationEngine; processes datasets, generates splits and evaluates runs</description>
   <organization>


### PR DESCRIPTION
Changed the docker image, because openjdk:11-slim-bullseye is not available anymore. See https://github.com/docker-library/openjdk/issues/505. 

This lead to an error while building the Evaluation docker image. See https://github.com/openml/EvaluationEngine/actions/runs/19172989547.